### PR TITLE
Add attachment management tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 *.tgz
 package-lock.json
 .idea/
+downloads/

--- a/README.md
+++ b/README.md
@@ -370,6 +370,34 @@ asana_update_task({
         * max_pages (number): Maximum pages to fetch when auto_paginate is true
     * Returns: Hierarchical project structure with statistics
 
+31. `asana_get_attachments_for_object`
+    * List attachments for a specific object (task, project, etc.)
+    * Required input:
+        * object_gid (string): The object GID to retrieve attachments for
+    * Optional input:
+        * limit (number): Results per page (1-100)
+        * offset (string): Pagination offset token
+        * opt_fields (string): Comma-separated list of optional fields to include
+    * Returns: List of attachments
+
+32. `asana_upload_attachment_for_object`
+    * Upload a local file as attachment to a task or other object
+    * Required input:
+        * object_gid (string): The object GID to attach the file to
+        * file_path (string): Path to the local file to upload
+    * Optional input:
+        * file_name (string): Custom file name
+        * file_type (string): MIME type of the uploaded file
+    * Returns: Metadata of the uploaded attachment
+
+33. `asana_download_attachment`
+    * Download an attachment to a local directory
+    * Required input:
+        * attachment_gid (string): The attachment GID to download
+    * Optional input:
+        * output_dir (string): Directory to save the file (default: ./downloads)
+    * Returns: Path and MIME type of the downloaded file
+
 ## Prompts
 
 1. `task-summary`

--- a/src/tool-handler.ts
+++ b/src/tool-handler.ts
@@ -47,11 +47,16 @@ import {
   getStoriesForTaskTool,
   createTaskStoryTool
 } from './tools/story-tools.js';
-import { 
+import {
   getTeamsForUserTool,
   getTeamsForWorkspaceTool,
-  getUsersForWorkspaceTool 
+  getUsersForWorkspaceTool
 } from './tools/user-tools.js';
+import {
+  getAttachmentsForObjectTool,
+  uploadAttachmentForObjectTool,
+  downloadAttachmentTool
+} from './tools/attachment-tools.js';
 
 export const tools: Tool[] = [
   listWorkspacesTool,
@@ -91,7 +96,10 @@ export const tools: Tool[] = [
   getTeamsForWorkspaceTool,
   addMembersForProjectTool,
   addFollowersForProjectTool,
-  getUsersForWorkspaceTool
+  getUsersForWorkspaceTool,
+  getAttachmentsForObjectTool,
+  uploadAttachmentForObjectTool,
+  downloadAttachmentTool
 ];
 
 // Exportăm și ca list_of_tools pentru compatibilitate cu index.ts
@@ -510,6 +518,30 @@ export function tool_handler(asanaClient: AsanaClientWrapper): (request: CallToo
           case "asana_get_users_for_workspace": {
             const { workspace_id, ...opts } = args;
             const response = await asanaClient.getUsersForWorkspace(workspace_id || undefined, opts);
+            return {
+              content: [{ type: "text", text: JSON.stringify(response) }],
+            };
+          }
+
+          case "asana_get_attachments_for_object": {
+            const { object_gid, ...opts } = args;
+            const response = await asanaClient.getAttachmentsForObject(object_gid, opts);
+            return {
+              content: [{ type: "text", text: JSON.stringify(response) }],
+            };
+          }
+
+          case "asana_upload_attachment_for_object": {
+            const { object_gid, file_path, file_name, file_type } = args;
+            const response = await asanaClient.uploadAttachmentForObject(object_gid, file_path, file_name, file_type);
+            return {
+              content: [{ type: "text", text: JSON.stringify(response) }],
+            };
+          }
+
+          case "asana_download_attachment": {
+            const { attachment_gid, output_dir } = args;
+            const response = await asanaClient.downloadAttachment(attachment_gid, output_dir);
             return {
               content: [{ type: "text", text: JSON.stringify(response) }],
             };

--- a/src/tools/attachment-tools.ts
+++ b/src/tools/attachment-tools.ts
@@ -1,0 +1,76 @@
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export const getAttachmentsForObjectTool: Tool = {
+  name: "asana_get_attachments_for_object",
+  description: "List attachments for an object (task, project, etc)",
+  inputSchema: {
+    type: "object",
+    properties: {
+      object_gid: {
+        type: "string",
+        description: "The object GID to get attachments for"
+      },
+      limit: {
+        type: "number",
+        description: "Results per page (1-100)",
+        minimum: 1,
+        maximum: 100
+      },
+      offset: {
+        type: "string",
+        description: "Pagination offset token"
+      },
+      opt_fields: {
+        type: "string",
+        description: "Comma-separated list of optional fields to include"
+      }
+    },
+    required: ["object_gid"]
+  }
+};
+
+export const uploadAttachmentForObjectTool: Tool = {
+  name: "asana_upload_attachment_for_object",
+  description: "Upload a local file as attachment to an object",
+  inputSchema: {
+    type: "object",
+    properties: {
+      object_gid: {
+        type: "string",
+        description: "The object GID to attach the file to"
+      },
+      file_path: {
+        type: "string",
+        description: "Path to the local file"
+      },
+      file_name: {
+        type: "string",
+        description: "Optional custom file name"
+      },
+      file_type: {
+        type: "string",
+        description: "Optional MIME type for the uploaded file"
+      }
+    },
+    required: ["object_gid", "file_path"]
+  }
+};
+
+export const downloadAttachmentTool: Tool = {
+  name: "asana_download_attachment",
+  description: "Download an attachment locally",
+  inputSchema: {
+    type: "object",
+    properties: {
+      attachment_gid: {
+        type: "string",
+        description: "The attachment GID to download"
+      },
+      output_dir: {
+        type: "string",
+        description: "Directory to save the file (defaults to ./downloads)"
+      }
+    },
+    required: ["attachment_gid"]
+  }
+};

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -355,6 +355,34 @@ export function validateSectionParameters(toolName: string, params: any): Valida
   };
 }
 
+export function validateAttachmentParameters(toolName: string, params: any): ValidationResult {
+  const errors: string[] = [];
+  let result: ValidationResult;
+
+  switch (toolName) {
+    case 'asana_get_attachments_for_object':
+      result = validateGid(params.object_gid, 'object_gid');
+      if (!result.valid) errors.push(...result.errors);
+      break;
+    case 'asana_upload_attachment_for_object':
+      result = validateGid(params.object_gid, 'object_gid');
+      if (!result.valid) errors.push(...result.errors);
+
+      result = validateString(params.file_path, 'file_path', false);
+      if (!result.valid) errors.push(...result.errors);
+      break;
+    case 'asana_download_attachment':
+      result = validateGid(params.attachment_gid, 'attachment_gid');
+      if (!result.valid) errors.push(...result.errors);
+      break;
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors
+  };
+}
+
 /**
  * Funcția principală pentru validarea parametrilor în funcție de operațiune
  * @param toolName Numele uneltei/operațiunii
@@ -377,6 +405,8 @@ export function validateParameters(toolName: string, params: any): ValidationRes
     return validateProjectParameters(toolName, params);
   } else if (toolName.includes('_section_')) {
     return validateSectionParameters(toolName, params);
+  } else if (toolName.includes('_attachment')) {
+    return validateAttachmentParameters(toolName, params);
   }
   
   // Pentru alte operațiuni care nu necesită validări specifice


### PR DESCRIPTION
## Summary
- create attachment-tools with upload, download and list functionality
- support attachments in tool-handler
- implement attachments methods in AsanaClientWrapper
- validate attachment parameters
- document new tools in README
- ignore downloads directory

## Testing
- `npx tsc -p tsconfig.json` *(fails: cannot find dependencies)*