### PR TITLE
Fix attachment download path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 *.tgz
 package-lock.json
 .idea/
+downloads/

--- a/README.md
+++ b/README.md
@@ -370,6 +370,34 @@ asana_update_task({
         * max_pages (number): Maximum pages to fetch when auto_paginate is true
     * Returns: Hierarchical project structure with statistics
 
+31. `asana_get_attachments_for_object`
+    * List attachments for a specific object (task, project, etc.)
+    * Required input:
+        * object_gid (string): The object GID to retrieve attachments for
+    * Optional input:
+        * limit (number): Results per page (1-100)
+        * offset (string): Pagination offset token
+        * opt_fields (string): Comma-separated list of optional fields to include
+    * Returns: List of attachments
+
+32. `asana_upload_attachment_for_object`
+    * Upload a local file as attachment to a task or other object
+    * Required input:
+        * object_gid (string): The object GID to attach the file to
+        * file_path (string): Path to the local file to upload
+    * Optional input:
+        * file_name (string): Custom file name
+        * file_type (string): MIME type of the uploaded file
+    * Returns: Metadata of the uploaded attachment
+
+33. `asana_download_attachment`
+    * Download an attachment to a local directory
+    * Required input:
+        * attachment_gid (string): The attachment GID to download
+    * Optional input:
+        * output_dir (string): Directory to save the file (default: ./downloads)
+    * Returns: Path and MIME type of the downloaded file
+
 ## Prompts
 
 1. `task-summary`

--- a/src/asana-client-wrapper.ts
+++ b/src/asana-client-wrapper.ts
@@ -9,6 +9,7 @@ export class AsanaClientWrapper {
   private stories: any;
   private projectStatuses: any;
   private tags: any;
+  private attachments: any;
   private sections: any;
   private users: any;
   private teams: any;
@@ -25,6 +26,7 @@ export class AsanaClientWrapper {
     this.stories = new Asana.StoriesApi();
     this.projectStatuses = new Asana.ProjectStatusesApi();
     this.tags = new Asana.TagsApi();
+    this.attachments = new Asana.AttachmentsApi();
     this.sections = new Asana.SectionsApi();
     this.users = new Asana.UsersApi();
     this.teams = new Asana.TeamsApi();
@@ -1483,5 +1485,90 @@ export class AsanaClientWrapper {
         throw error; // Aruncăm eroarea originală
       }
     }
+  }
+
+  async getAttachmentsForObject(objectId: string, opts: any = {}) {
+    const response = await this.attachments.getAttachmentsForObject(objectId, opts);
+    return response.data;
+  }
+
+  async getAttachment(attachmentId: string, opts: any = {}) {
+    const response = await this.attachments.getAttachment(attachmentId, opts);
+    return response.data;
+  }
+
+  async uploadAttachmentForObject(objectId: string, filePath: string, fileName?: string, fileType?: string) {
+    const fs = await import('fs');
+    const path = await import('path');
+
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`File not found: ${filePath}`);
+    }
+
+    const form = new FormData();
+    const name = fileName || path.basename(filePath);
+    const fileStream = fs.createReadStream(filePath);
+    form.append('parent', objectId);
+    form.append('file', fileStream, fileType ? { filename: name, contentType: fileType } : name);
+
+    const token = Asana.ApiClient.instance.authentications['token'].accessToken;
+    const response = await fetch('https://app.asana.com/api/1.0/attachments', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: form as any
+    });
+
+    if (!response.ok) {
+      throw new Error(`Upload failed: ${response.status} ${await response.text()}`);
+    }
+
+    const result = await response.json();
+    return result.data;
+  }
+
+  private extensionForMime(mime: string): string {
+    const map: Record<string, string> = {
+      'image/jpeg': '.jpg',
+      'image/png': '.png',
+      'image/gif': '.gif',
+      'application/pdf': '.pdf',
+      'text/plain': '.txt',
+      'application/zip': '.zip',
+      'application/json': '.json'
+    };
+    return map[mime] || '';
+  }
+
+  async downloadAttachment(attachmentId: string, outputDir: string = 'downloads') {
+    const fs = await import('fs');
+    const path = await import('path');
+    const { pipeline } = await import('stream/promises');
+
+    const attachment = await this.getAttachment(attachmentId);
+    const downloadUrl = attachment.download_url || attachment.downloadUrl;
+    if (!downloadUrl) {
+      throw new Error('Attachment does not have a download_url');
+    }
+
+    const resolvedDir = path.resolve(process.cwd(), outputDir);
+    await fs.promises.mkdir(resolvedDir, { recursive: true });
+
+    const token = Asana.ApiClient.instance.authentications['token'].accessToken;
+    const res = await fetch(downloadUrl, { headers: { Authorization: `Bearer ${token}` } });
+    if (!res.ok || !res.body) {
+      throw new Error(`Failed to download attachment: ${res.status}`);
+    }
+
+    let filename: string = attachment.name || attachment.gid;
+    const contentType = res.headers.get('content-type') || attachment.mime_type;
+    if (!path.extname(filename) && contentType) {
+      filename += this.extensionForMime(contentType);
+    }
+
+    const filePath = path.join(resolvedDir, filename);
+    const fileStream = fs.createWriteStream(filePath);
+    await pipeline(res.body, fileStream);
+
+    return { attachment_id: attachmentId, file_path: filePath, mime_type: contentType };
   }
 }

--- a/src/tool-handler.ts
+++ b/src/tool-handler.ts
@@ -47,11 +47,16 @@ import {
   getStoriesForTaskTool,
   createTaskStoryTool
 } from './tools/story-tools.js';
-import { 
+import {
   getTeamsForUserTool,
   getTeamsForWorkspaceTool,
-  getUsersForWorkspaceTool 
+  getUsersForWorkspaceTool
 } from './tools/user-tools.js';
+import {
+  getAttachmentsForObjectTool,
+  uploadAttachmentForObjectTool,
+  downloadAttachmentTool
+} from './tools/attachment-tools.js';
 
 export const tools: Tool[] = [
   listWorkspacesTool,
@@ -91,7 +96,10 @@ export const tools: Tool[] = [
   getTeamsForWorkspaceTool,
   addMembersForProjectTool,
   addFollowersForProjectTool,
-  getUsersForWorkspaceTool
+  getUsersForWorkspaceTool,
+  getAttachmentsForObjectTool,
+  uploadAttachmentForObjectTool,
+  downloadAttachmentTool
 ];
 
 // Exportăm și ca list_of_tools pentru compatibilitate cu index.ts
@@ -510,6 +518,30 @@ export function tool_handler(asanaClient: AsanaClientWrapper): (request: CallToo
           case "asana_get_users_for_workspace": {
             const { workspace_id, ...opts } = args;
             const response = await asanaClient.getUsersForWorkspace(workspace_id || undefined, opts);
+            return {
+              content: [{ type: "text", text: JSON.stringify(response) }],
+            };
+          }
+
+          case "asana_get_attachments_for_object": {
+            const { object_gid, ...opts } = args;
+            const response = await asanaClient.getAttachmentsForObject(object_gid, opts);
+            return {
+              content: [{ type: "text", text: JSON.stringify(response) }],
+            };
+          }
+
+          case "asana_upload_attachment_for_object": {
+            const { object_gid, file_path, file_name, file_type } = args;
+            const response = await asanaClient.uploadAttachmentForObject(object_gid, file_path, file_name, file_type);
+            return {
+              content: [{ type: "text", text: JSON.stringify(response) }],
+            };
+          }
+
+          case "asana_download_attachment": {
+            const { attachment_gid, output_dir } = args;
+            const response = await asanaClient.downloadAttachment(attachment_gid, output_dir);
             return {
               content: [{ type: "text", text: JSON.stringify(response) }],
             };

--- a/src/tools/attachment-tools.ts
+++ b/src/tools/attachment-tools.ts
@@ -1,0 +1,76 @@
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export const getAttachmentsForObjectTool: Tool = {
+  name: "asana_get_attachments_for_object",
+  description: "List attachments for an object (task, project, etc)",
+  inputSchema: {
+    type: "object",
+    properties: {
+      object_gid: {
+        type: "string",
+        description: "The object GID to get attachments for"
+      },
+      limit: {
+        type: "number",
+        description: "Results per page (1-100)",
+        minimum: 1,
+        maximum: 100
+      },
+      offset: {
+        type: "string",
+        description: "Pagination offset token"
+      },
+      opt_fields: {
+        type: "string",
+        description: "Comma-separated list of optional fields to include"
+      }
+    },
+    required: ["object_gid"]
+  }
+};
+
+export const uploadAttachmentForObjectTool: Tool = {
+  name: "asana_upload_attachment_for_object",
+  description: "Upload a local file as attachment to an object",
+  inputSchema: {
+    type: "object",
+    properties: {
+      object_gid: {
+        type: "string",
+        description: "The object GID to attach the file to"
+      },
+      file_path: {
+        type: "string",
+        description: "Path to the local file"
+      },
+      file_name: {
+        type: "string",
+        description: "Optional custom file name"
+      },
+      file_type: {
+        type: "string",
+        description: "Optional MIME type for the uploaded file"
+      }
+    },
+    required: ["object_gid", "file_path"]
+  }
+};
+
+export const downloadAttachmentTool: Tool = {
+  name: "asana_download_attachment",
+  description: "Download an attachment locally",
+  inputSchema: {
+    type: "object",
+    properties: {
+      attachment_gid: {
+        type: "string",
+        description: "The attachment GID to download"
+      },
+      output_dir: {
+        type: "string",
+        description: "Directory to save the file (defaults to ./downloads)"
+      }
+    },
+    required: ["attachment_gid"]
+  }
+};

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -355,6 +355,34 @@ export function validateSectionParameters(toolName: string, params: any): Valida
   };
 }
 
+export function validateAttachmentParameters(toolName: string, params: any): ValidationResult {
+  const errors: string[] = [];
+  let result: ValidationResult;
+
+  switch (toolName) {
+    case 'asana_get_attachments_for_object':
+      result = validateGid(params.object_gid, 'object_gid');
+      if (!result.valid) errors.push(...result.errors);
+      break;
+    case 'asana_upload_attachment_for_object':
+      result = validateGid(params.object_gid, 'object_gid');
+      if (!result.valid) errors.push(...result.errors);
+
+      result = validateString(params.file_path, 'file_path', false);
+      if (!result.valid) errors.push(...result.errors);
+      break;
+    case 'asana_download_attachment':
+      result = validateGid(params.attachment_gid, 'attachment_gid');
+      if (!result.valid) errors.push(...result.errors);
+      break;
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors
+  };
+}
+
 /**
  * Funcția principală pentru validarea parametrilor în funcție de operațiune
  * @param toolName Numele uneltei/operațiunii
@@ -377,6 +405,8 @@ export function validateParameters(toolName: string, params: any): ValidationRes
     return validateProjectParameters(toolName, params);
   } else if (toolName.includes('_section_')) {
     return validateSectionParameters(toolName, params);
+  } else if (toolName.includes('_attachment')) {
+    return validateAttachmentParameters(toolName, params);
   }
   
   // Pentru alte operațiuni care nu necesită validări specifice


### PR DESCRIPTION
## Summary
- resolve output directory in attachment downloads to avoid mkdir errors

## Testing
- `npx tsc -p tsconfig.json` *(fails: cannot find module dependencies)*
- `node build.js` *(fails: cannot find package 'esbuild')*