### PR TITLE
Switch MCP server to SSE

### DIFF
--- a/MCP_GUIDE_ARCHITECTURE.md
+++ b/MCP_GUIDE_ARCHITECTURE.md
@@ -38,13 +38,13 @@ src/
 #### a. Entry Point (index.ts)
 - Server initialization
 - Environment configuration
-- Transport setup (typically stdio)
+- Transport setup (SSE in this server)
 - Error handling
 - Request handler registration
 
 ```typescript
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { SseServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { tool_handler, list_of_tools } from './tool-handler.js';
 import { createPromptHandlers } from './prompt-handler.js';
 import { ClientWrapper } from './client-wrapper.js';
@@ -73,7 +73,7 @@ async function main() {
   server.setRequestHandler(ListPromptsRequestSchema, promptHandlers.listPrompts);
   server.setRequestHandler(GetPromptRequestSchema, promptHandlers.getPrompt);
   
-  const transport = new StdioServerTransport();
+  const transport = new SseServerTransport();
   await server.connect(transport);
 }
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { VERSION } from './version.js';
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { SseServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { tool_handler, list_of_tools } from './tool-handler.js';
 import {
   CallToolRequestSchema,
@@ -72,11 +72,11 @@ async function main() {
     };
   });
 
-  const transport = new StdioServerTransport();
+  const transport = new SseServerTransport();
   console.error("Connecting server to transport...");
   await server.connect(transport);
 
-  console.error("Asana MCP Server running on stdio");
+  console.error("Asana MCP Server running on SSE");
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary
- connect the server using `SseServerTransport`
- update architecture guide to document SSE usage

## Testing
- `npm run build` *(fails: Cannot find package 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_68429c97892083239cfa64fc08704b40